### PR TITLE
STEP14

### DIFF
--- a/src/main/java/io/hhplus/ecommerce/domain/service/product/FindProductService.java
+++ b/src/main/java/io/hhplus/ecommerce/domain/service/product/FindProductService.java
@@ -8,16 +8,23 @@ import io.hhplus.ecommerce.infra.product.ProductJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
 public class FindProductService {
+
     private static final Logger log = LoggerFactory.getLogger(FindProductService.class);
     private final ProductJpaRepository productJpaRepository;
 
@@ -39,18 +46,20 @@ public class FindProductService {
                 .build();
     }
 
-    /**
-     * 최근 3일간 판매 상위 5개 상품 조회
-     */
-    public List<ProductDto> getTopFiveProducts() {
-        // 최근 3일의 시작 날짜 계산 00시 기준
-        LocalDateTime startDate = LocalDate.now().minusDays(3).atStartOfDay();
 
+    /**
+     * 최근 3일간 판매 상위 5개 상품을 캐시에서 조회하고, 없으면 DB에서 조회 후 캐시에 저장
+     */
+    @Transactional(readOnly = true)
+    @Cacheable(value = "topProductsCache", key = "'topfiveproduct'")
+    public List<ProductDto> getTopFiveProducts() {
+        // DB에서 최근 3일간의 상위 5개 상품 조회
+        LocalDateTime startDate = LocalDate.now().minusDays(3).atStartOfDay();
         List<Product> topProducts = productJpaRepository.findTop5Product(startDate);
 
-        if (topProducts == null || topProducts.isEmpty()) {
-            log.error("get Top Five Products Data Null or Empty");
-            throw new ResourceNotFoundException(ErrorCode.PRODUCT_NOT_FOUND);
+        if (topProducts.isEmpty()) {
+            log.warn("No top products found in the last 3 days");
+            return Collections.emptyList();
         }
 
         return topProducts.stream()
@@ -60,6 +69,31 @@ public class FindProductService {
                         .price(product.getPrice())
                         .stock(product.getStock())
                         .build())
-                .toList();
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 매일 자정에 상위 5개 상품 캐시 갱신
+     */
+    @Transactional(readOnly = true)
+    @Scheduled(cron = "0 0 0 * * *")  // 매일 자정 00시에 실행
+    @CachePut(value = "topProductsCache", key = "'topfiveproduct'")
+    public List<ProductDto> cacheTopFiveProducts() {
+        LocalDateTime startDate = LocalDate.now().minusDays(3).atStartOfDay();
+        List<Product> topProducts = productJpaRepository.findTop5Product(startDate);
+
+        if (topProducts.isEmpty()) {
+            log.warn("No top products found in the last 3 days for cache update");
+            return Collections.emptyList();
+        }
+
+        return topProducts.stream()
+                .map(product -> ProductDto.builder()
+                        .productId(product.getProductId())
+                        .name(product.getName())
+                        .price(product.getPrice())
+                        .stock(product.getStock())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/io/hhplus/ecommerce/domain/service/product/cache/ProductCacheConfig.java
+++ b/src/main/java/io/hhplus/ecommerce/domain/service/product/cache/ProductCacheConfig.java
@@ -1,0 +1,39 @@
+package io.hhplus.ecommerce.domain.service.product.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class ProductCacheConfig {
+
+    /**
+     * RedisCacheManager 설정: topProductsCache의 TTL을 24시간으로 설정
+     */
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+
+        // Redis Cache 설정
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(1))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+}

--- a/src/test/java/io/hhplus/ecommerce/domain/service/product/FindProductCacheTest.java
+++ b/src/test/java/io/hhplus/ecommerce/domain/service/product/FindProductCacheTest.java
@@ -1,0 +1,99 @@
+package io.hhplus.ecommerce.domain.service.product;
+
+import io.hhplus.ecommerce.application.dto.product.ProductDto;
+import io.hhplus.ecommerce.domain.entity.order.Order;
+import io.hhplus.ecommerce.domain.entity.order.OrderDetail;
+import io.hhplus.ecommerce.domain.entity.product.Product;
+import io.hhplus.ecommerce.domain.entity.user.User;
+import io.hhplus.ecommerce.support.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class FindProductCacheTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        setUpTestData();
+    }
+
+    private void setUpTestData() {
+        // 사용자 생성
+        User user = User.builder()
+                .name("Test User")
+                .point(new BigDecimal("1000.00"))
+                .build();
+        userJpaRepository.save(user);
+
+        // 제품 생성
+        Product product1 = Product.builder()
+                .name("Product 1")
+                .price(new BigDecimal("100.00"))
+                .stock(50)
+                .build();
+        Product product2 = Product.builder()
+                .name("Product 2")
+                .price(new BigDecimal("200.00"))
+                .stock(30)
+                .build();
+        productJpaRepository.saveAll(Arrays.asList(product1, product2));
+
+        // 주문 생성
+        Order order = Order.builder()
+                .user(user)
+                .orderDate(LocalDateTime.now())
+                .orderDetails(Arrays.asList(
+                        OrderDetail.builder().product(product1).quantity(2).build(),
+                        OrderDetail.builder().product(product2).quantity(1).build()
+                ))
+                .build();
+        orderJpaRepository.save(order);
+    }
+
+    @Test
+    @DisplayName("Redis Cache에 상위 5개 제품이 잘 저장되고 조회되는지 확인")
+    public void getTopFiveProducts_CacheTest() {
+        // Given
+        List<Product> products = Arrays.asList(
+                Product.builder().productId(1L).name("Product 1").price(new BigDecimal("100.00")).stock(50).build(),
+                Product.builder().productId(2L).name("Product 2").price(new BigDecimal("200.00")).stock(30).build()
+        );
+
+        // Fetch top products and cache them
+        List<ProductDto> topProducts = findProductService.getTopFiveProducts();
+        assertEquals(2, topProducts.size());
+        assertEquals("Product 1", topProducts.get(0).getName());
+        assertEquals("Product 2", topProducts.get(1).getName());
+
+        // Verify that products are cached in Redis
+        RBucket<List<ProductDto>> cachedProductsBucket = redissonClient.getBucket("topProductsCache::topfiveproduct");
+        List<ProductDto> cachedProducts = cachedProductsBucket.get();
+        assertThat(cachedProducts).isNotNull();
+        assertEquals(2, cachedProducts.size());
+        assertEquals("Product 1", cachedProducts.get(0).getName());
+        assertEquals("Product 2", cachedProducts.get(1).getName());
+
+        // Call again to check if cache works
+        List<ProductDto> cachedProductsAgain = findProductService.getTopFiveProducts();
+        assertEquals(2, cachedProductsAgain.size());
+    }
+}


### PR DESCRIPTION
# 상품 캐싱 로직

## 기능
1. **상위 5개 상품 조회**: 최근 3일간 판매된 상위 5개 상품을 Redis 캐시에서 조회하고, 캐시에 없을 경우 데이터베이스에서 조회하여 캐시에 저장합니다.
   - **캐시 키**: `topProductsCache`의 키는 `'topfiveproduct'`로 설정되어 있습니다.
2. **캐시 갱신**: 매일 자정에 상위 5개 상품 정보를 데이터베이스에서 조회하여 캐시를 갱신합니다.
   - **TTL**: 캐시의 유효 기간(Time To Live)은 24시간으로 설정되어 있습니다.

## 문제 해결
- **성능 개선**: 캐시를 사용하여 데이터베이스 접근을 최소화함으로써 성능을 향상시킵니다.
- **최신 데이터 보장**: 매일 자정에 캐시를 갱신하여 최신 상위 상품 정보를 제공합니다.

## 부족한 점
- **성능 테스트 미비**: 현재 구현된 캐싱 로직에 대한 성능 테스트가 이루어지지 않아 실제 운영 환경에서의 성능을 검증할 수 없습니다. 
주말동안 `검증예정..`

- **예외 처리 부족**: 데이터베이스 조회 중 발생할 수 있는 예외에 대한 처리가 없습니다.

## 리뷰 포인트
- 레디스 캐시적용 할때 config 설정과 서비스에 구현방식에 틀린부분이 있는지 확인 부탁드립니다.
